### PR TITLE
Fix setup.py to install python-gflags using pip3 on Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='python-gflags',
       author='Google Inc. and others',
       author_email='google-gflags@googlegroups.com',
       url='https://github.com/google/python-gflags',
-      py_modules=['gflags'],
+      packages=['gflags', 'gflags/third_party/pep257'],
       data_files=[('bin', ['gflags2man.py'])],
       include_package_data=True,
      )


### PR DESCRIPTION
I had been using

```
pip3 install https://github.com/joachimmetz/python-gflags/archive/python3.zip
```

to install your python3 branch. That stopped working recently because gflags.py was removed. This patch to setup.py makes it work again, for example:

```
pip3 install https://github.com/jamesbursa/python-gflags/archive/python3.zip
```

There are still some warnings but the installation using pip3 works.